### PR TITLE
Added helper asset () to link JS and CSS files

### DIFF
--- a/src/Notify.php
+++ b/src/Notify.php
@@ -114,24 +114,24 @@ class Notify {
      */
     public function scripts() {
 
-        $scripts = '<link href="vendor/Notify/themify-icons.css" rel="stylesheet" type="text/css">
+        $scripts = '<link href="'. asset('vendor/Notify/themify-icons.css') .'" rel="stylesheet" type="text/css">
                    
-                   <script type="text/javascript" src="vendor/Notify/jquery/jquery-3.2.1.min.js"></script>';
+                   <script type="text/javascript" src="'. asset('vendor/Notify/jquery/jquery-3.2.1.min.js') .'"></script>';
 
         if ($this->options['lib'] === 'toastr'):
-            $scripts .= '<link href="vendor/Notify/toastr/toastr.min.css" rel="stylesheet" type="text/css">
-                         <script type="text/javascript" src="vendor/Notify/toastr/toastr.min.js"></script>';
+            $scripts .= '<link href="'. asset('vendor/Notify/toastr/toastr.min.css') .'" rel="stylesheet" type="text/css">
+                        <script type="text/javascript" src="'. asset('vendor/Notify/toastr/toastr.min.js') .'"></script>';
         elseif ($this->options['lib'] === 'pnotify'):
-            $scripts .= '<link href="vendor/Notify/animate.css" rel="stylesheet" type="text/css">
-                         <link href="vendor/Notify/pnotify/pnotify.custom.min.css" rel="stylesheet" type="text/css">
-                         <script type="text/javascript" src="vendor/Notify/pnotify/pnotify.custom.min.js"></script>';
+            $scripts .= '<link href="'. asset('vendor/Notify/animate.css') .'" rel="stylesheet" type="text/css">
+                         <link href="'. asset('vendor/Notify/pnotify/pnotify.custom.min.css') .'" rel="stylesheet" type="text/css">
+                         <script type="text/javascript" src="'. asset('vendor/Notify/pnotify/pnotify.custom.min.js') .'"></script>';
             if ($this->config['desktop']['desktop'] === true):
                 $scripts .= 'PNotify.desktop.permission();';
             endif;
         endif;
 
         if ($this->options['style'] === 'custom'):
-            $scripts .= '<link href="vendor/Notify/style.css" rel="stylesheet" type="text/css">';
+            $scripts .= '<link href="'. asset('vendor/Notify/style.css') .'" rel="stylesheet" type="text/css">';
         endif;
 
         return $scripts;


### PR DESCRIPTION
Sem o método asset() os arquivos CSS e JS não eram encontrados quando se acessava por uma URL mysite.com.br/admin/dashboard por exemplo.