### PR TITLE
Auto register providers and aliases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,15 @@
             "Helmesvs\\Notify\\": "src/"
         }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Helmesvs\\Notify\\NotifyServiceProvider"
+            ],
+            "aliases": {
+                "Notify": "Helmesvs\\Notify\\Facades\\Notify::class"
+            }
+        }
+    }
 }


### PR DESCRIPTION
From version 5.5 of Laravel it is possible to add input to automatically register the providers and the aliases